### PR TITLE
Resolve build error due to internal api change

### DIFF
--- a/f1_schedule_telegram_bot/main.py
+++ b/f1_schedule_telegram_bot/main.py
@@ -36,11 +36,11 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # For private chats, register using the username,
     # otherwise use the group name for identification
-    name = ""
+    chatName = ""
     if update.effective_chat.type == telegram.constants.ChatType.PRIVATE:
-        name = update.effective_chat.username
+        chatName = update.effective_chat.username
     else:
-        name = update.effective_chat.title
+        chatName = update.effective_chat.title
 
     try:
         chat = database.get_chat(dbconn, chat_id)
@@ -59,7 +59,7 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
             {
                 "chat_id": chat_id,
                 "type": update.effective_chat.type,
-                "name": name,
+                "name": chatName,
             },
         )
         dbconn.commit()

--- a/f1_schedule_telegram_bot/main.py
+++ b/f1_schedule_telegram_bot/main.py
@@ -36,11 +36,11 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # For private chats, register using the username,
     # otherwise use the group name for identification
-    chatName = ""
+    name = ""
     if update.effective_chat.type == telegram.constants.ChatType.PRIVATE:
-        chatName = update.effective_chat.username
+        name = update.effective_chat.username
     else:
-        chatName = update.effective_chat.title
+        name = update.effective_chat.title
 
     try:
         chat = database.get_chat(dbconn, chat_id)
@@ -59,7 +59,7 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
             {
                 "chat_id": chat_id,
                 "type": update.effective_chat.type,
-                "name": chatName,
+                "name": name,
             },
         )
         dbconn.commit()

--- a/poetry.lock
+++ b/poetry.lock
@@ -186,14 +186,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
 ]
 
 [[package]]
@@ -631,21 +631,21 @@ files = [
 
 [[package]]
 name = "pydocstyle"
-version = "6.3.0"
+version = "6.1.1"
 description = "Python docstring style checker"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
+    {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
+    {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
 ]
 
 [package.dependencies]
-snowballstemmer = ">=2.2.0"
+snowballstemmer = "*"
 
 [package.extras]
-toml = ["tomli (>=1.2.3)"]
+toml = ["toml"]
 
 [[package]]
 name = "pyflakes"
@@ -1164,4 +1164,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "e9f60ed5c7449f7f3475de5cfedd84d46e50f91ff587d62200f46a973b449f5d"
+content-hash = "a8aa5acafe655d2ec859db871a983101133278ca59ac08f2022393b67a1a2df1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ issues = "https://github.com/Fastjur/F1ScheduleTelegramBot/issues"
 # linters = "pycodestyle,pydocstyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
 linters = "pycodestyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
 ignore = "D202,D203,D212,W1203"
+# Skip .venv in github actions
+skip = ".venv/*"
 
 [tool.vulture]
 min_confidence = 70

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ main = "f1_schedule_telegram_bot.main:main"
 issues = "https://github.com/Fastjur/F1ScheduleTelegramBot/issues"
 
 [tool.pylama]
-# linters = "pycodestyle,pydocstyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
-linters = "pycodestyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
+linters = "pycodestyle,pydocstyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
 ignore = "D202,D203,D212,W1203"
 # Skip .venv in github actions
 skip = ".venv/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ main = "f1_schedule_telegram_bot.main:main"
 issues = "https://github.com/Fastjur/F1ScheduleTelegramBot/issues"
 
 [tool.pylama]
-linters = "pycodestyle,pydocstyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
+# linters = "pycodestyle,pydocstyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
+linters = "pycodestyle,pyflakes,mccabe,pylint,radon,mypy,vulture"
 ignore = "D202,D203,D212,W1203"
 
 [tool.vulture]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ arrow = "^1.2.3"
 pylama = {extras = ["toml", "mypy", "pylint", "eradicate", "radon", "vulture"], version = "^8.4.1"}
 black = "^23.3.0"
 types-requests = "^2.30.0.0"
+# Lock pydocstyle to a version lower than 6.2, otherwise the build errors
+# https://github.com/klen/pylama/issues/232
+pydocstyle = "^6.0.0, <6.2.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Due to an internal API change, versions are incompatible. By pinning to a lower version this will work. At a later point the pin does have to be removed after a new release is made of the package using `pydocstyle`.

https://github.com/klen/pylama/issues/232

This also disables linting the `.venv`